### PR TITLE
fix(openclaw): correct configmap name reference

### DIFF
--- a/apps/openclaw/values.yaml
+++ b/apps/openclaw/values.yaml
@@ -123,7 +123,7 @@ app-template:
     config:
       enabled: true
       type: configMap
-      name: openclaw-config
+      name: openclaw
       advancedMounts:
         main:
           main:


### PR DESCRIPTION
## Summary
- Fixed ConfigMap name reference from `openclaw-config` to `openclaw` to match the actual ConfigMap created by the app-template Helm chart

## Issue
The deployment was looking for a ConfigMap named `openclaw-config` but the Helm chart creates it as `openclaw`. This was causing pod startup failures with `MountVolume.SetUp failed for volume config: configmap openclaw-config not found`.

## Root Cause
The app-template chart naming convention changed, and the persistence volume reference was not updated accordingly.